### PR TITLE
RENAME from Decentralized Web Primer to IPFS Primer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This primer contains a series of Tutorials explaining IPFS, Merkle Trees and the
 
 When this is finished, this primer should serve as a complete replacement for the examples at https://ipfs.io/docs/examples/
 
-The github repository for this book is at https://github.com/flyingzumwalt/ipfs-primer
+The github repository for this book is at https://github.com/ipfs-shipyard/ipfs-primer.
+
+_Note: Until January 2020, the repository was at https://github.com/flyingzumwalt/decentralized-web-primer. It was moved to the ipfs-shipyard and renamed to IPFS Primer for clarity and to make it easier for people to contribute.)_
 
 # Getting Help
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This primer contains a series of Tutorials explaining IPFS, Merkle Trees and the Decentralized Web. It's written and maintained as a [gitbook](https://www.gitbook.com/about) so people can read it in many formats.
 
-When this is finished, this primer will be a complete replacement for the examples at https://ipfs.io/docs/examples/
+When this is finished, this primer should serve as a complete replacement for the examples at https://ipfs.io/docs/examples/
 
 The github repository for this book is at https://github.com/flyingzumwalt/ipfs-primer
 

--- a/avenues-for-access/lessons/tor-transport.md
+++ b/avenues-for-access/lessons/tor-transport.md
@@ -24,7 +24,7 @@ Work-In-Progress: https://github.com/ipfs/notes/issues/37
 
 Work-In-Progress: https://github.com/OpenBazaar/go-onion-transport
 
-TODO - *This explanation has not been written yet. If you want to help work on it, or if you want to encourage us to give it attention, open an issue at https://github.com/flyingzumwalt/ipfs-primer/issues*
+TODO - *This explanation has not been written yet. If you want to help work on it, or if you want to encourage us to give it attention, open an issue at https://github.com/ipfs-shipyard/ipfs-primer/issues*
 
 ### Step 2: Start the IPFS daemon
 

--- a/avenues-for-access/lessons/tor-transport.md
+++ b/avenues-for-access/lessons/tor-transport.md
@@ -24,7 +24,7 @@ Work-In-Progress: https://github.com/ipfs/notes/issues/37
 
 Work-In-Progress: https://github.com/OpenBazaar/go-onion-transport
 
-TODO - *This explanation has not been written yet. If you want to help work on it, or if you want to encourage us to give it attention, open an issue at https://github.com/flyingzumwalt/decentralized-web-primer/issues*
+TODO - *This explanation has not been written yet. If you want to help work on it, or if you want to encourage us to give it attention, open an issue at https://github.com/flyingzumwalt/ipfs-primer/issues*
 
 ### Step 2: Start the IPFS daemon
 

--- a/build-book.sh
+++ b/build-book.sh
@@ -3,10 +3,10 @@
 echo "building html"
 gitbook build
 echo "building pdf"
-gitbook pdf ./ _book/decentralized-web-primer.pdf
+gitbook pdf ./ _book/ipfs-primer.pdf
 echo "building epub"
-gitbook epub ./ _book/decentralized-web-primer.epub
+gitbook epub ./ _book/ipfs-primer.epub
 echo "building mobi"
-gitbook mobi ./ _book/decentralized-web-primer.mobi
+gitbook mobi ./ _book/ipfs-primer.mobi
 
 echo "...done. Everything is in _book/"

--- a/going-online/README.md
+++ b/going-online/README.md
@@ -20,4 +20,3 @@ These Lessons will teach you how to
 1. [Lesson: Connect your node to the IPFS network](/going-online/lessons/connect-your-node.md)
 2. [Lesson: Find Peers on the Network](/going-online/lessons/find-peers.md)
 3. [Lesson: Retrieve content from a Peer](/going-online/lessons/retrieve-from-peer.md)
-

--- a/ipfs-dag/lessons/files-as-dags.md
+++ b/ipfs-dag/lessons/files-as-dags.md
@@ -10,7 +10,7 @@
 
 ### Step 1: Download the sample file and add it to IPFS
 
-For this lesson we need a file that's larger than 256kb. Download this image: [tree-in-cosmos.jpg](https://raw.githubusercontent.com/flyingzumwalt/ipfs-primer/master/samples/tree-in-cosmos.jpg) (863kb)
+For this lesson we need a file that's larger than 256kb. Download this image: [tree-in-cosmos.jpg](https://raw.githubusercontent.com/ipfs-shipyard/ipfs-primer/master/samples/tree-in-cosmos.jpg) (863kb)
 
 Save it as "tree-in-cosmos.jpg" and then add it to IPFS
 

--- a/ipfs-dag/lessons/files-as-dags.md
+++ b/ipfs-dag/lessons/files-as-dags.md
@@ -10,7 +10,7 @@
 
 ### Step 1: Download the sample file and add it to IPFS
 
-For this lesson we need a file that's larger than 256kb. Download this image: [tree-in-cosmos.jpg](https://raw.githubusercontent.com/flyingzumwalt/decentralized-web-primer/master/samples/tree-in-cosmos.jpg) (863kb)
+For this lesson we need a file that's larger than 256kb. Download this image: [tree-in-cosmos.jpg](https://raw.githubusercontent.com/flyingzumwalt/ipfs-primer/master/samples/tree-in-cosmos.jpg) (863kb)
 
 Save it as "tree-in-cosmos.jpg" and then add it to IPFS
 


### PR DESCRIPTION
Replace references to decentralized-web-primer with ipfs-primer. See Issue #42 for more info. Will apply this after people like @edgo914 get to apply their existing changes.